### PR TITLE
[bzip2]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.bzip2?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # bzip2
 
 [bzip2][1] is a freely available, patent free (see below), high-quality data compressor.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# bzip2
+
+[bzip2][1] is a freely available, patent free (see below), high-quality data compressor.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+To use this plan, include it in your `pkg_build_deps` or `pkg_deps`, for example:
+
+```
+pkg_build_deps=(core/bzip2)
+```
+
+or use it directly:
+
+```
+hab pkg install core/bzip2 --binlink
+bzip2
+```
+
+[1]: http://www.bzip.org/

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_relative_path: '/bin/bzip2'

--- a/controls/bzip2_exists.rb
+++ b/controls/bzip2_exists.rb
@@ -7,7 +7,8 @@ control 'core-plans-bzip2-exists' do
   impact 1.0
   title 'Ensure bzip2 exists'
   desc '
-  '
+  Verify bzip2 by ensuring /bin/bzip2 exists'
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/controls/bzip2_exists.rb
+++ b/controls/bzip2_exists.rb
@@ -1,0 +1,22 @@
+title 'Tests to confirm bzip2 exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'bzip2')
+ 
+control 'core-plans-bzip2-exists' do
+  impact 1.0
+  title 'Ensure bzip2 exists'
+  desc '
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: '/bin/bzip2')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  describe file(command_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/bzip2_works.rb
+++ b/controls/bzip2_works.rb
@@ -1,0 +1,27 @@
+title 'Tests to confirm bzip2 works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'bzip2')
+
+control 'core-plans-bzip2-works' do
+  impact 1.0
+  title 'Ensure bzip2 works as expected'
+  desc '
+  Note: Since bzip2 --version not only outputs its version info to stderr
+  but also random text to stout, then only the stderr is being checked in
+  the test
+  '
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} bzip2 --version") do
+    its('exit_status') { should eq 0 }
+    its('stderr') { should_not be_empty }
+    its('stderr') { should match /bzip2, a block-sorting file compressor.  Version #{plan_pkg_version}/ }
+  end
+end

--- a/controls/bzip2_works.rb
+++ b/controls/bzip2_works.rb
@@ -7,10 +7,12 @@ control 'core-plans-bzip2-works' do
   impact 1.0
   title 'Ensure bzip2 works as expected'
   desc '
-  Note: Since bzip2 --version not only outputs its version info to stderr
-  but also random text to stout, then only the stderr is being checked in
-  the test
+  Verify bzip2 by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version.    Note that since bzip2 --version not only 
+  outputs its version info to stderr but also random text to stout, then the stdout
+  content is being ignored, only the stderr validated.
   '
+  
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: bzip2
+title: Habitat Core Plan bzip2
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan bzip2
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.ps1
+++ b/plan.ps1
@@ -1,0 +1,30 @@
+$pkg_name="bzip2"
+$pkg_origin="core"
+$pkg_version="1.0.8"
+$pkg_file_name=$pkg_name + ($pkg_version).Replace(".", "")
+$pkg_description="bzip2 is a free and open-source file compression program that uses the Burrows-Wheeler algorithm. It only compresses single files and is not a file archiver."
+$pkg_upstream_url="http://www.bzip.org/"
+$pkg_license=("bzip2")
+$pkg_source="https://fossies.org/linux/misc/${pkg_name}-${pkg_version}.zip"
+$pkg_shasum="7585f461a58476bb2697642b5bd4e6fb173404a5e59ae8cd557226b0fd388405"
+$pkg_deps=@("core/visual-cpp-redist-2015")
+$pkg_build_deps=@("core/visual-cpp-build-tools-2015")
+$pkg_bin_dirs=@("bin")
+$pkg_lib_dirs=@("lib")
+$pkg_include_dirs=@("include")
+
+function Invoke-SetupEnvironment {
+    . "$(Get-HabPackagePath visual-cpp-build-tools-2015)\setenv.ps1"
+}
+function Invoke-Build {
+    Set-Location "$pkg_name-$pkg_version"
+    nmake -f makefile.msc
+    if($LASTEXITCODE -ne 0) { Write-Error "nmake failed!" }
+}
+
+function Invoke-Install {
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\bzip2.exe" "$pkg_prefix\bin\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\bzip2recover.exe" "$pkg_prefix\bin\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\bzlib.h" "$pkg_prefix\include\" -Force
+    Copy-Item "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version\libbz2.lib" "$pkg_prefix\lib\" -Force
+}

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,87 @@
+pkg_name=bzip2
+_distname=$pkg_name
+pkg_origin=core
+pkg_version=1.0.8
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+bzip2 is a free and open-source file compression program that uses the \
+Burrows–Wheeler algorithm. It only compresses single files and is not a file \
+archiver.\
+"
+pkg_upstream_url="http://www.bzip.org/"
+pkg_license=('bzip2')
+pkg_source="https://fossies.org/linux/misc/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="ab5a03176ee106d3f0fa90e381da478ddae405918153cca248e682cd0c4a2269"
+pkg_dirname="${_distname}-${pkg_version}"
+pkg_deps=(
+  core/glibc
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+_common_prepare() {
+  # Makes the symbolic links in installation relative vs. absolute
+  # shellcheck disable=SC2016
+  sed -i 's@\(ln -s -f \)$(PREFIX)/bin/@\1@' Makefile
+
+  # Ensure that the man pages are installed under share/man
+  sed -i "s@(PREFIX)/man@(PREFIX)/share/man@g" Makefile
+}
+
+do_prepare() {
+  _common_prepare
+
+  export CC=gcc
+  build_line "Setting CC=$CC"
+}
+
+do_build() {
+  make -f Makefile-libbz2_so PREFIX="$pkg_prefix" CC="$CC"
+  make bzip2 bzip2recover CC="$CC" LDFLAGS="$LDFLAGS"
+}
+
+do_check() {
+  make test
+}
+
+do_install() {
+  local maj maj_min
+  maj=$(echo $pkg_version | cut -d "." -f 1)
+  maj_min=$(echo $pkg_version | cut -d "." -f 1-2)
+
+  make install PREFIX="$pkg_prefix"
+
+  # Replace some hard links with symlinks
+  rm -fv "$pkg_prefix/bin"/{bunzip2,bzcat}
+  ln -sv bzip2 "$pkg_prefix/bin/bunzip2"
+  ln -sv bzip2 "$pkg_prefix/bin/bzcat"
+
+  # Install the shared library and its symlinks
+  cp -v "$HAB_CACHE_SRC_PATH/$pkg_dirname/libbz2.so.$pkg_version" \
+    "$pkg_prefix/lib"
+  ln -sv "libbz2.so.$pkg_version" "$pkg_prefix/lib/libbz2.so"
+  ln -sv "libbz2.so.$pkg_version" "$pkg_prefix/lib/libbz2.so.$maj"
+  ln -sv "libbz2.so.$pkg_version" "$pkg_prefix/lib/libbz2.so.$maj_min"
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,5 @@
+expected_version="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+@test "bzip2 version matches ${expected_version}" {
+  actual_version="$(hab pkg exec "${TEST_PKG_IDENT}" bzip2 --help 2>&1 | grep -oP '(?<=Version )([^,]*)')"
+  diff <( echo "${actual_version}" ) <( echo "${expected_version}" )
+}

--- a/tests/test.pester.ps1
+++ b/tests/test.pester.ps1
@@ -1,0 +1,15 @@
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Fully qualified package identifier must be given as a parameter.")
+)
+
+$PackageVersion = $PackageIdentifier.split('/')[2]
+Describe "core/bzip2" {
+    Context "bzip2" {
+        $OutputVariable = (hab pkg exec $pkg_ident bzip2 --help *>&1 | Out-String)
+        $OutputVariable -match "(?<=Version )([^,]*)"
+        It "returns version that matches the $PackageVersion" {
+            $matches[0] | Should -BeExactly "$PackageVersion"
+        }
+    }
+}

--- a/tests/test.ps1
+++ b/tests/test.ps1
@@ -1,0 +1,22 @@
+# Ensure package ident has been passed
+param (
+    [Parameter()]
+    [string]$PackageIdentifier = $(throw "Usage: test.ps1 [test_pgk_ident] e.g. test.ps1 core/7zip/16.04/20190513101258")
+)
+
+# Ensure Pester is installed
+if (-Not (Get-Module -ListAvailable -Name Pester)) {
+    hab pkg install core/pester
+    Import-Module "$(hab pkg path core/pester)\module\pester.psd1"
+}
+
+# Install the package
+hab pkg install $PackageIdentifier
+
+# Test the package
+$__dir=(Get-Item $PSScriptRoot)
+$test_result = Invoke-Pester -PassThru -Script @{
+    Path = "$__dir/test.pester.ps1";
+    Parameters = @{PackageIdentifier=$PackageIdentifier}
+}
+Exit $test_result.FailedCount

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -euo pipefail
+
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/opa/0.11.0/20190531065119
+#/
+
+TESTDIR="$(dirname "${0}")"
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+  exit 1
+fi
+
+TEST_PKG_IDENT="$1"
+
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+
+export TEST_PKG_IDENT
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
```rspec
+ hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://498823197e8e975be8513cb5bffd46b74fcd2bcc25bd4ee2057559135af619c1 --input-file /src/attributes.yml

Profile: Habitat Core Plan bzip2 (bzip2)
Version: 0.1.0
Target:  docker://498823197e8e975be8513cb5bffd46b74fcd2bcc25bd4ee2057559135af619c1

  ✔  core-plans-bzip2-exists: Ensure bzip2 exists
     ✔  File /hab/pkgs/core/bzip2/1.0.8/20200602211701/bin/bzip2 is expected to exist
  ✔  core-plans-bzip2-works: Ensure bzip2 works as expected
     ✔  Command: `hab pkg path core/bzip2` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/bzip2` stdout is expected not to be empty
     ✔  Command: `hab pkg exec core/bzip2/1.0.8/20200602211701 bzip2 --version` exit_status is expected to eq 0
     ✔  Command: `hab pkg exec core/bzip2/1.0.8/20200602211701 bzip2 --version` stderr is expected to match /bzip2, a block-sorting file compressor.  Version 1.0.8/


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 5 successful, 0 failures, 0 skipped
+ set +x
[21][default:/src:0]# 
```